### PR TITLE
Fix.typo 

### DIFF
--- a/orderbook-types/src/generated/private_transfer_erc20.rs
+++ b/orderbook-types/src/generated/private_transfer_erc20.rs
@@ -5,7 +5,7 @@ use bigdecimal;
 use uuid;
 /**Transfer ERC20 assets from one subaccount to another (e.g. USDC or ETH).
 
-For transfering positions (e.g. options or perps), use `private/transfer_position` instead.*/
+For transferring positions (e.g. options or perps), use `private/transfer_position` instead.*/
 ///
 /// <details><summary>JSON schema</summary>
 ///

--- a/orderbook-types/src/generated/public_get_spot_feed_history.rs
+++ b/orderbook-types/src/generated/public_get_spot_feed_history.rs
@@ -457,7 +457,7 @@ for PublicGetSpotFeedHistoryResultSchema {
     },
     "timestamp": {
       "title": "timestamp",
-      "description": "Timestamp of when the spot price was recored into the database",
+      "description": "Timestamp of when the spot price was recorded into the database",
       "type": "integer"
     },
     "timestamp_bucket": {


### PR DESCRIPTION


- "I fixed a typo in the `private_transfer_erc20.rs` file, changing 'transfering' to 'transferring' in the comment."
- "I corrected a typo in the `public_get_spot_feed_history.rs` file, changing 'recored' to 'recorded' in the description of the timestamp field."